### PR TITLE
feat: add template selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,6 +206,7 @@
             <div class="card" style="background:rgba(21,23,42,.75); border-color:#323761">
               <h3>Outputs — Products I produced</h3>
               <div class="grid grid-2">
+                <div><label>Template</label><select id="outTemplate" class="input"></select></div>
                 <div><label>Product Type</label><select id="outProdType" class="input"></select></div>
                 <div id="otherProdWrap" class="hide"><label>Other (specify)</label><input id="otherProd" class="input" placeholder="e.g., Podcast episode"/></div>
                 <div><label>Quantity</label><input id="outQty" type="number" min="1" class="input" value="1"/></div>
@@ -220,6 +221,7 @@
             <div class="card" style="background:rgba(21,23,42,.75); border-color:#323761">
               <h3>Outtakes — Engagements & reach</h3>
               <div class="grid grid-2">
+                <div><label>Template</label><select id="otkTemplate" class="input"></select></div>
                 <div><label>Outtake Type</label><select id="otkType" class="input"></select></div>
                 <div id="otkOtherWrap" class="hide"><label>Other (specify)</label><input id="otkOther" class="input" placeholder="e.g., Survey completes"/></div>
                 <div><label>Quantity</label><input id="otkQty" type="number" min="1" class="input" value="1"/></div>
@@ -388,7 +390,24 @@ const STORAGE_KEY='nww_pao_metrics_onepage_v1';
 const def={
   adminPIN:'0000',
   staff:[], // {id,name,pin}
-  templates:{ outputs:['Story','Photos','Social media posts','News release','Video','Graphic','Fact sheet'], outtakes:['Event attendees','Stakeholder briefings','Media engagements','Website clicks','Email signups'] },
+  templates:{
+    outputs:[
+      {name:'Story', qty:1, links:[]},
+      {name:'Photos', qty:1, links:[]},
+      {name:'Social media posts', qty:1, links:[]},
+      {name:'News release', qty:1, links:[]},
+      {name:'Video', qty:1, links:[]},
+      {name:'Graphic', qty:1, links:[]},
+      {name:'Fact sheet', qty:1, links:[]}
+    ],
+    outtakes:[
+      {name:'Event attendees', qty:1, notes:''},
+      {name:'Stakeholder briefings', qty:1, notes:''},
+      {name:'Media engagements', qty:1, notes:''},
+      {name:'Website clicks', qty:1, notes:''},
+      {name:'Email signups', qty:1, notes:''}
+    ]
+  },
   goals:{ M:{outputs:{},outtakes:{},outcomes:[]}, Q:{outputs:{},outtakes:{},outcomes:[]}, Y:{outputs:{},outtakes:{},outcomes:[]} },
   entries:[], // metrics: {id,userId,type:'output'|'outtake'|'outcome', tf, tfKey, ts, data:{...}}
   kle:[],    // KLE
@@ -572,13 +591,33 @@ const tfStaffSel=$('#tfStaff'), tfStaffPick=$('#tfStaffPick');
 tfStaffSel?.addEventListener('change', ()=> buildTfPicker(tfStaffPick, tfStaffSel.value, key=>{cur.tf=tfStaffSel.value; cur.key=key; refreshStaff();}));
 function buildStaff(){
   // populate pickers
-  $('#outProdType').innerHTML = [...db.templates.outputs, 'Other (specify)'].map(t=>`<option>${t}</option>`).join('');
-  $('#otkType').innerHTML    = [...db.templates.outtakes, 'Other (specify)'].map(t=>`<option>${t}</option>`).join('');
+  $('#outTemplate').innerHTML = `<option value="">Select template</option>` + db.templates.outputs.map(t=>`<option>${t.name}</option>`).join('');
+  $('#outProdType').innerHTML = [...db.templates.outputs.map(t=>t.name), 'Other (specify)'].map(t=>`<option>${t}</option>`).join('');
+  $('#otkTemplate').innerHTML = `<option value="">Select template</option>` + db.templates.outtakes.map(t=>`<option>${t.name}</option>`).join('');
+  $('#otkType').innerHTML    = [...db.templates.outtakes.map(t=>t.name), 'Other (specify)'].map(t=>`<option>${t}</option>`).join('');
   buildTfPicker(tfStaffPick, tfStaffSel.value, key=>{cur.key=key; refreshStaff();});
   const sel=$('#ocmKey'); sel.innerHTML=''; (db.goals[cur.tf].outcomes||[]).forEach(o=> sel.appendChild(new Option(o.name,o.name)));
 }
 $('#outProdType').addEventListener('change', ()=> $('#otherProdWrap').classList.toggle('hide', $('#outProdType').value!=='Other (specify)'));
 $('#otkType').addEventListener('change', ()=> $('#otkOtherWrap').classList.toggle('hide', $('#otkType').value!=='Other (specify)'));
+$('#outTemplate').addEventListener('change', ()=>{
+  const t=db.templates.outputs.find(o=>o.name===$('#outTemplate').value);
+  if(t){
+    $('#outProdType').value=t.name;
+    $('#outQty').value=t.qty||1;
+    $('#outLinks').value=(t.links||[]).join('\n');
+    $('#outProdType').dispatchEvent(new Event('change'));
+  }
+});
+$('#otkTemplate').addEventListener('change', ()=>{
+  const t=db.templates.outtakes.find(o=>o.name===$('#otkTemplate').value);
+  if(t){
+    $('#otkType').value=t.name;
+    $('#otkQty').value=t.qty||1;
+    $('#otkNotes').value=t.notes||'';
+    $('#otkType').dispatchEvent(new Event('change'));
+  }
+});
 $('#ocmPct').addEventListener('input', e=> $('#ocmVal').textContent = e.target.value+'%');
 $('#btnAddOutput').addEventListener('click', ()=>{
   if(!user) return; const type=$('#outProdType').value==='Other (specify)' ? ($('#otherProd').value.trim()||'Other') : $('#outProdType').value;
@@ -619,7 +658,7 @@ function refreshViewerIf(){ if(!$('#screenViewer').classList.contains('hide')) r
 const tfAdminSel=$('#tfAdmin'), tfAdminPick=$('#tfAdminPick');
 tfAdminSel?.addEventListener('change', ()=> buildTfPicker(tfAdminPick, tfAdminSel.value, key=>{cur.tf=tfAdminSel.value; cur.key=key; buildGoalsEditors(); refreshAdminDash();}));
 function buildAdmin(){
-  $('#tplOutputs').value=db.templates.outputs.join('\n'); $('#tplOuttakes').value=db.templates.outtakes.join('\n');
+  $('#tplOutputs').value=db.templates.outputs.map(t=>t.name).join('\n'); $('#tplOuttakes').value=db.templates.outtakes.map(t=>t.name).join('\n');
   buildTfPicker(tfAdminPick, tfAdminSel.value, key=>{cur.key=key; buildGoalsEditors(); refreshAdminDash();});
   renderStaffList();
   if(db.apiKeys){
@@ -640,7 +679,11 @@ function buildAdmin(){
   $('#btnSaveAdminPIN').onclick=()=>{ const p=$('#setAdminPIN').value.trim(); if(!p) return alert('Enter a PIN'); db.adminPIN=p; save(); $('#setAdminPIN').value=''; alert('Admin PIN updated'); };
 }
   $('#btnAddStaff').onclick=()=>{ const name=$('#staffName').value.trim(), pin=$('#staffNewPIN').value.trim(); if(!name||!pin) return alert('Name & PIN required'); let rec=db.staff.find(s=>s.name.toLowerCase()===name.toLowerCase()); if(rec) rec.pin=pin; else db.staff.push({id:uid(),name,pin}); save(); $('#staffName').value=''; $('#staffNewPIN').value=''; renderStaffList(); };
-  $('#btnSaveTemplates').onclick=()=>{ db.templates.outputs=$('#tplOutputs').value.split('\n').map(s=>s.trim()).filter(Boolean); db.templates.outtakes=$('#tplOuttakes').value.split('\n').map(s=>s.trim()).filter(Boolean); save(); alert('Templates saved'); };
+  $('#btnSaveTemplates').onclick=()=>{
+    db.templates.outputs=$('#tplOutputs').value.split('\n').map(s=>s.trim()).filter(Boolean).map(name=>({name, qty:1, links:[]}));
+    db.templates.outtakes=$('#tplOuttakes').value.split('\n').map(s=>s.trim()).filter(Boolean).map(name=>({name, qty:1, notes:''}));
+    save(); alert('Templates saved');
+  };
   $('#btnExport').onclick=()=>{ const blob=new Blob([JSON.stringify(db,null,2)],{type:'application/json'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='nww_pao_metrics_export.json'; a.click(); };
   $('#importFile').onchange=(e)=>{ const f=e.target.files[0]; if(!f) return; const fr=new FileReader(); fr.onload=()=>{ try{ db=JSON.parse(fr.result); save(); alert('Imported. Reloading…'); location.reload(); }catch(err){ alert('Invalid JSON'); } }; fr.readAsText(f); };
   $('#btnReset').onclick=()=>{ if(!confirm('Wipe all local data?'))return; localStorage.removeItem(STORAGE_KEY); location.reload(); };
@@ -656,12 +699,14 @@ function renderStaffList(){
 }
 function buildGoalsEditors(){
   const g=db.goals[cur.tf];
-  const go=$('#goalsOutputs'); go.innerHTML=''; db.templates.outputs.forEach(name=>{
+  const go=$('#goalsOutputs'); go.innerHTML=''; db.templates.outputs.forEach(t=>{
+    const name=t.name;
     const val=g.outputs[name]||0; const r=document.createElement('div'); r.className='card'; r.style.cssText='background:#0e1124;border-color:#2f355e';
     r.innerHTML=`<div style="display:flex;justify-content:space-between;align-items:center"><div><span class="chip">${name}</span></div><div style="min-width:180px"><input type="range" min="0" max="50" value="${val}" data-name="${name}" class="goalOutRange"><div class="mini"><span class="val">${val}</span> products</div></div></div>`;
     go.appendChild(r);
   });
-  const gt=$('#goalsOuttakes'); gt.innerHTML=''; db.templates.outtakes.forEach(name=>{
+  const gt=$('#goalsOuttakes'); gt.innerHTML=''; db.templates.outtakes.forEach(t=>{
+    const name=t.name;
     const val=g.outtakes[name]||0; const r=document.createElement('div'); r.className='card'; r.style.cssText='background:#0e1124;border-color:#2f355e';
     r.innerHTML=`<div style="display:flex;justify-content:space-between;align-items:center"><div><span class="chip">${name}</span></div><div style="min-width:180px"><input type="range" min="0" max="50" value="${val}" data-name="${name}" class="goalOtkRange"><div class="mini"><span class="val">${val}</span> events/qty</div></div></div>`;
     gt.appendChild(r);
@@ -854,7 +899,7 @@ function buildChecklist(){
       <div class="mini">Required approvals: ${approvals}</div>
       <div class="grid grid-3" style="margin-top:8px">
         <div><label>Product Title</label><input id="chkTitle" class="input" placeholder="e.g., Water Safety News Release"></div>
-        <div><label>Product Type</label><select id="chkType" class="input">${db.templates.outputs.map(t=>`<option>${t}</option>`).join('')}<option>Other</option></select></div>
+          <div><label>Product Type</label><select id="chkType" class="input">${db.templates.outputs.map(t=>`<option>${t.name}</option>`).join('')}<option>Other</option></select></div>
         <div><label>Links (comma or new line)</label><input id="chkLinks" class="input" placeholder="Drafts, assets, DVIDS, etc."></div>
       </div>
       <div class="grid grid-2" style="margin-top:12px">
@@ -895,10 +940,6 @@ function renderChecklist(){
 }
 
 /* ================= INIT ================= */
-function buildViewer() { /* picker wired above */ }
-function buildStaff()  { /* pickers wired in handlers */   }
-function buildAdmin()  { /* wired above */ }
-
 (function init(){
   show('role');
   // Viewer picker default


### PR DESCRIPTION
## Summary
- expand stored templates to objects with preset qty and notes
- add template dropdowns for outputs/outtakes and auto-fill related fields
- save updated template structure from admin editor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0844e5dcc83289332ce2cd6d3831c