### PR TITLE
feat: expand template editor with default data

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,8 +296,16 @@
             <div class="card" style="background:#ffffff22;border-color:#ffffff55">
               <h3>Templates</h3>
               <div class="grid" style="grid-template-columns:1fr">
-                <div><label>Output Product Types</label><textarea id="tplOutputs" rows="6" class="input"></textarea></div>
-                <div><label>Outtake Types</label><textarea id="tplOuttakes" rows="6" class="input"></textarea></div>
+                <div>
+                  <label>Output Product Types</label>
+                  <div id="tplOutputs"></div>
+                  <button class="ghost small" id="addTplOutput" style="margin-top:6px">Add Template</button>
+                </div>
+                <div>
+                  <label>Outtake Types</label>
+                  <div id="tplOuttakes"></div>
+                  <button class="ghost small" id="addTplOuttake" style="margin-top:6px">Add Template</button>
+                </div>
               </div>
               <div style="display:flex; gap:10px; margin-top:10px">
                 <button class="cta" id="btnSaveTemplates">Save Templates</button>
@@ -388,7 +396,24 @@ const STORAGE_KEY='nww_pao_metrics_onepage_v1';
 const def={
   adminPIN:'0000',
   staff:[], // {id,name,pin}
-  templates:{ outputs:['Story','Photos','Social media posts','News release','Video','Graphic','Fact sheet'], outtakes:['Event attendees','Stakeholder briefings','Media engagements','Website clicks','Email signups'] },
+  templates:{
+    outputs:[
+      {name:'Story', qty:1, links:[]},
+      {name:'Photos', qty:1, links:[]},
+      {name:'Social media posts', qty:1, links:[]},
+      {name:'News release', qty:1, links:[]},
+      {name:'Video', qty:1, links:[]},
+      {name:'Graphic', qty:1, links:[]},
+      {name:'Fact sheet', qty:1, links:[]}
+    ],
+    outtakes:[
+      {name:'Event attendees', qty:1, links:[]},
+      {name:'Stakeholder briefings', qty:1, links:[]},
+      {name:'Media engagements', qty:1, links:[]},
+      {name:'Website clicks', qty:1, links:[]},
+      {name:'Email signups', qty:1, links:[]}
+    ]
+  },
   goals:{ M:{outputs:{},outtakes:{},outcomes:[]}, Q:{outputs:{},outtakes:{},outcomes:[]}, Y:{outputs:{},outtakes:{},outcomes:[]} },
   entries:[], // metrics: {id,userId,type:'output'|'outtake'|'outcome', tf, tfKey, ts, data:{...}}
   kle:[],    // KLE
@@ -398,8 +423,22 @@ const def={
   checklists:[], // pre-release
   apiKeys:{ facebook:'', instagram:'', x:'', linkedin:'' }
 };
-let db = load(); function load(){ try{const raw=localStorage.getItem(STORAGE_KEY); return raw? JSON.parse(raw): (localStorage.setItem(STORAGE_KEY, JSON.stringify(def)), structuredClone(def)); }catch(e){ return structuredClone(def);} }
+let db = load();
+migrateTemplates();
+function load(){ try{const raw=localStorage.getItem(STORAGE_KEY); return raw? JSON.parse(raw): (localStorage.setItem(STORAGE_KEY, JSON.stringify(def)), structuredClone(def)); }catch(e){ return structuredClone(def);} }
 function save(){ localStorage.setItem(STORAGE_KEY, JSON.stringify(db)); }
+function migrateTemplates(){
+  let changed=false;
+  if(Array.isArray(db.templates?.outputs) && typeof db.templates.outputs[0] === 'string'){
+    db.templates.outputs = db.templates.outputs.map(name=>({name, qty:1, links:[]}));
+    changed=true;
+  }
+  if(Array.isArray(db.templates?.outtakes) && typeof db.templates.outtakes[0] === 'string'){
+    db.templates.outtakes = db.templates.outtakes.map(name=>({name, qty:1, links:[]}));
+    changed=true;
+  }
+  if(changed) save();
+}
 
 /* ================= HELPERS ================= */
 const $=s=>document.querySelector(s); const $$=s=>Array.from(document.querySelectorAll(s));
@@ -414,6 +453,29 @@ function monthKey(d){return `${d.getFullYear()}-${String(d.getMonth()+1).padStar
 function quarter(d){return Math.floor(d.getMonth()/3)+1}
 function quarterKey(d){return `${d.getFullYear()}-Q${quarter(d)}`}
 function tfKeyOf(tf, dLike){const d = dLike? new Date(dLike): new Date(); if(tf==='M') return monthKey(d); if(tf==='Q') return quarterKey(d); return String(year(d))}
+
+function addTemplateRow(box, tpl={name:'',qty:1,links:[]}){
+  const row=document.createElement('div');
+  row.className='tplRow';
+  row.style.cssText='display:flex;gap:6px;margin-top:6px';
+  row.innerHTML=`<input class="input tplName" placeholder="Name" value="${tpl.name||''}" style="flex:1">`+
+    `<input class="input tplQty mono" type="number" min="0" value="${tpl.qty ?? 1}" style="width:80px">`+
+    `<input class="input tplLinks" placeholder="Links" value="${(tpl.links||[]).join(', ')}" style="flex:2">`+
+    `<button class="danger small removeTpl">Remove</button>`;
+  row.querySelector('.removeTpl').onclick=()=> row.remove();
+  box.appendChild(row);
+}
+function renderTemplateRows(box, list){
+  box.innerHTML='';
+  list.forEach(t=> addTemplateRow(box,t));
+}
+function readTemplateRows(box){
+  return Array.from(box.querySelectorAll('.tplRow')).map(r=>({
+    name:r.querySelector('.tplName').value.trim(),
+    qty:parseInt(r.querySelector('.tplQty').value||'0',10),
+    links:parseLinks(r.querySelector('.tplLinks').value)
+  })).filter(t=>t.name);
+}
 
 /* ================= STATE ================= */
 let role=null, user=null, cur={tf:'M',key:tfKeyOf('M')};
@@ -572,8 +634,8 @@ const tfStaffSel=$('#tfStaff'), tfStaffPick=$('#tfStaffPick');
 tfStaffSel?.addEventListener('change', ()=> buildTfPicker(tfStaffPick, tfStaffSel.value, key=>{cur.tf=tfStaffSel.value; cur.key=key; refreshStaff();}));
 function buildStaff(){
   // populate pickers
-  $('#outProdType').innerHTML = [...db.templates.outputs, 'Other (specify)'].map(t=>`<option>${t}</option>`).join('');
-  $('#otkType').innerHTML    = [...db.templates.outtakes, 'Other (specify)'].map(t=>`<option>${t}</option>`).join('');
+  $('#outProdType').innerHTML = [...db.templates.outputs.map(t=>t.name), 'Other (specify)'].map(t=>`<option>${t}</option>`).join('');
+  $('#otkType').innerHTML    = [...db.templates.outtakes.map(t=>t.name), 'Other (specify)'].map(t=>`<option>${t}</option>`).join('');
   buildTfPicker(tfStaffPick, tfStaffSel.value, key=>{cur.key=key; refreshStaff();});
   const sel=$('#ocmKey'); sel.innerHTML=''; (db.goals[cur.tf].outcomes||[]).forEach(o=> sel.appendChild(new Option(o.name,o.name)));
 }
@@ -619,7 +681,10 @@ function refreshViewerIf(){ if(!$('#screenViewer').classList.contains('hide')) r
 const tfAdminSel=$('#tfAdmin'), tfAdminPick=$('#tfAdminPick');
 tfAdminSel?.addEventListener('change', ()=> buildTfPicker(tfAdminPick, tfAdminSel.value, key=>{cur.tf=tfAdminSel.value; cur.key=key; buildGoalsEditors(); refreshAdminDash();}));
 function buildAdmin(){
-  $('#tplOutputs').value=db.templates.outputs.join('\n'); $('#tplOuttakes').value=db.templates.outtakes.join('\n');
+  renderTemplateRows($('#tplOutputs'), db.templates.outputs);
+  $('#addTplOutput').onclick=()=> addTemplateRow($('#tplOutputs'), {name:'', qty:1, links:[]});
+  renderTemplateRows($('#tplOuttakes'), db.templates.outtakes);
+  $('#addTplOuttake').onclick=()=> addTemplateRow($('#tplOuttakes'), {name:'', qty:1, links:[]});
   buildTfPicker(tfAdminPick, tfAdminSel.value, key=>{cur.key=key; buildGoalsEditors(); refreshAdminDash();});
   renderStaffList();
   if(db.apiKeys){
@@ -640,7 +705,11 @@ function buildAdmin(){
   $('#btnSaveAdminPIN').onclick=()=>{ const p=$('#setAdminPIN').value.trim(); if(!p) return alert('Enter a PIN'); db.adminPIN=p; save(); $('#setAdminPIN').value=''; alert('Admin PIN updated'); };
 }
   $('#btnAddStaff').onclick=()=>{ const name=$('#staffName').value.trim(), pin=$('#staffNewPIN').value.trim(); if(!name||!pin) return alert('Name & PIN required'); let rec=db.staff.find(s=>s.name.toLowerCase()===name.toLowerCase()); if(rec) rec.pin=pin; else db.staff.push({id:uid(),name,pin}); save(); $('#staffName').value=''; $('#staffNewPIN').value=''; renderStaffList(); };
-  $('#btnSaveTemplates').onclick=()=>{ db.templates.outputs=$('#tplOutputs').value.split('\n').map(s=>s.trim()).filter(Boolean); db.templates.outtakes=$('#tplOuttakes').value.split('\n').map(s=>s.trim()).filter(Boolean); save(); alert('Templates saved'); };
+  $('#btnSaveTemplates').onclick=()=>{
+    db.templates.outputs = readTemplateRows($('#tplOutputs'));
+    db.templates.outtakes = readTemplateRows($('#tplOuttakes'));
+    save(); alert('Templates saved');
+  };
   $('#btnExport').onclick=()=>{ const blob=new Blob([JSON.stringify(db,null,2)],{type:'application/json'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='nww_pao_metrics_export.json'; a.click(); };
   $('#importFile').onchange=(e)=>{ const f=e.target.files[0]; if(!f) return; const fr=new FileReader(); fr.onload=()=>{ try{ db=JSON.parse(fr.result); save(); alert('Imported. Reloading…'); location.reload(); }catch(err){ alert('Invalid JSON'); } }; fr.readAsText(f); };
   $('#btnReset').onclick=()=>{ if(!confirm('Wipe all local data?'))return; localStorage.removeItem(STORAGE_KEY); location.reload(); };
@@ -656,13 +725,13 @@ function renderStaffList(){
 }
 function buildGoalsEditors(){
   const g=db.goals[cur.tf];
-  const go=$('#goalsOutputs'); go.innerHTML=''; db.templates.outputs.forEach(name=>{
-    const val=g.outputs[name]||0; const r=document.createElement('div'); r.className='card'; r.style.cssText='background:#0e1124;border-color:#2f355e';
+  const go=$('#goalsOutputs'); go.innerHTML=''; db.templates.outputs.forEach(t=>{
+    const name=t.name; const val=g.outputs[name]||0; const r=document.createElement('div'); r.className='card'; r.style.cssText='background:#0e1124;border-color:#2f355e';
     r.innerHTML=`<div style="display:flex;justify-content:space-between;align-items:center"><div><span class="chip">${name}</span></div><div style="min-width:180px"><input type="range" min="0" max="50" value="${val}" data-name="${name}" class="goalOutRange"><div class="mini"><span class="val">${val}</span> products</div></div></div>`;
     go.appendChild(r);
   });
-  const gt=$('#goalsOuttakes'); gt.innerHTML=''; db.templates.outtakes.forEach(name=>{
-    const val=g.outtakes[name]||0; const r=document.createElement('div'); r.className='card'; r.style.cssText='background:#0e1124;border-color:#2f355e';
+  const gt=$('#goalsOuttakes'); gt.innerHTML=''; db.templates.outtakes.forEach(t=>{
+    const name=t.name; const val=g.outtakes[name]||0; const r=document.createElement('div'); r.className='card'; r.style.cssText='background:#0e1124;border-color:#2f355e';
     r.innerHTML=`<div style="display:flex;justify-content:space-between;align-items:center"><div><span class="chip">${name}</span></div><div style="min-width:180px"><input type="range" min="0" max="50" value="${val}" data-name="${name}" class="goalOtkRange"><div class="mini"><span class="val">${val}</span> events/qty</div></div></div>`;
     gt.appendChild(r);
   });
@@ -854,7 +923,7 @@ function buildChecklist(){
       <div class="mini">Required approvals: ${approvals}</div>
       <div class="grid grid-3" style="margin-top:8px">
         <div><label>Product Title</label><input id="chkTitle" class="input" placeholder="e.g., Water Safety News Release"></div>
-        <div><label>Product Type</label><select id="chkType" class="input">${db.templates.outputs.map(t=>`<option>${t}</option>`).join('')}<option>Other</option></select></div>
+        <div><label>Product Type</label><select id="chkType" class="input">${db.templates.outputs.map(t=>`<option>${t.name}</option>`).join('')}<option>Other</option></select></div>
         <div><label>Links (comma or new line)</label><input id="chkLinks" class="input" placeholder="Drafts, assets, DVIDS, etc."></div>
       </div>
       <div class="grid grid-2" style="margin-top:12px">


### PR DESCRIPTION
## Summary
- replace template textareas with repeatable rows for name, default quantity, and links
- save templates as objects and migrate older string arrays automatically
- update forms and goals to use new template structure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0845b94bc8328afe60e40ec106e54