### PR TITLE
Add accessible stepper with progress announcements

### DIFF
--- a/rpie.html
+++ b/rpie.html
@@ -136,16 +136,30 @@
           <textarea id="policy" placeholder="Tone, style, sensitivities, risk items, do-not-mentions..."></textarea>
         </details>
 
-        <details open>
-          <summary>Step 1 — Identify communication requirements</summary>
+        <div id="stepper" class="tabs" role="tablist" aria-label="Plan steps">
+          <button type="button" class="tab" role="tab" aria-selected="true" data-step="1">Step 1</button>
+          <button type="button" class="tab" role="tab" aria-selected="false" data-step="2">Step 2</button>
+          <button type="button" class="tab" role="tab" aria-selected="false" data-step="3">Step 3</button>
+          <button type="button" class="tab" role="tab" aria-selected="false" data-step="4">Step 4</button>
+          <button type="button" class="tab" role="tab" aria-selected="false" data-step="5">Step 5</button>
+          <button type="button" class="tab" role="tab" aria-selected="false" data-step="6">Step 6</button>
+          <button type="button" class="tab" role="tab" aria-selected="false" data-step="7">Step 7</button>
+          <button type="button" class="tab" role="tab" aria-selected="false" data-step="8">Step 8</button>
+          <button type="button" class="tab" role="tab" aria-selected="false" data-step="9">Step 9</button>
+          <button type="button" class="tab" role="tab" aria-selected="false" data-step="10">Step 10</button>
+        </div>
+        <div id="progress" class="help" aria-live="polite"></div>
+
+        <div class="step-pane" id="step1" role="tabpanel">
+          <h3>Step 1 — Identify communication requirements</h3>
           <label for="issue">Issue statement</label>
           <textarea id="issue" placeholder="Define the issue, scope, and required support."></textarea>
           <label for="requirements">Requirements</label>
           <textarea id="requirements" placeholder="Key products, approvals, timing, authorities."></textarea>
-        </details>
+        </div>
 
-        <details>
-          <summary>Step 2 — Analyze the current situation</summary>
+        <div class="step-pane" id="step2" role="tabpanel" hidden aria-hidden="true">
+          <h3>Step 2 — Analyze the current situation</h3>
           <label for="situation">Situation analysis</label>
           <textarea id="situation" placeholder="Context, constraints, opportunities."></textarea>
           <div class="row">
@@ -156,10 +170,10 @@
             <div><label for="swotO">Opportunities</label><textarea id="swotO"></textarea></div>
             <div><label for="swotT">Threats</label><textarea id="swotT"></textarea></div>
           </div>
-        </details>
+        </div>
 
-        <details>
-          <summary>Step 3 — Stakeholders and target audiences</summary>
+        <div class="step-pane" id="step3" role="tabpanel" hidden aria-hidden="true">
+          <h3>Step 3 — Stakeholders and target audiences</h3>
           <label>Business lines</label>
           <div id="businessLinesList" class="taglist"></div>
           <div class="tagadd">
@@ -190,18 +204,18 @@
 
           <label for="audienceNotes" style="margin-top:10px">Notes (audience priorities, sensitivities)</label>
           <textarea id="audienceNotes"></textarea>
-        </details>
+        </div>
 
-        <details>
-          <summary>Step 4 — Goals and SMART objectives</summary>
+        <div class="step-pane" id="step4" role="tabpanel" hidden aria-hidden="true">
+          <h3>Step 4 — Goals and SMART objectives</h3>
           <label for="goals">Goals</label>
           <textarea id="goals" placeholder="Desired end state, long term focus."></textarea>
           <label for="objectives">SMART objectives</label>
           <textarea id="objectives" placeholder="Specific, Measurable, Achievable, Relevant, Time-bound."></textarea>
-        </details>
+        </div>
 
-        <details>
-          <summary>Step 5 — Strategies, tactics, key messages, talking points</summary>
+        <div class="step-pane" id="step5" role="tabpanel" hidden aria-hidden="true">
+          <h3>Step 5 — Strategies, tactics, key messages, talking points</h3>
           <label for="strategies">Strategies</label>
           <textarea id="strategies" placeholder="How to reach goals and objectives."></textarea>
           <label for="tactics">Tactics</label>
@@ -210,10 +224,10 @@
           <textarea id="messages" placeholder="27-9-3 structure encouraged."></textarea>
           <label for="talking">Talking points</label>
           <textarea id="talking"></textarea>
-        </details>
+        </div>
 
-        <details>
-          <summary>Step 6 — Budget</summary>
+        <div class="step-pane" id="step6" role="tabpanel" hidden aria-hidden="true">
+          <h3>Step 6 — Budget</h3>
           <div class="row">
             <div><label for="labor">Labor</label><input id="labor" type="text" placeholder="$ or hours"/></div>
             <div><label for="materials">Materials</label><input id="materials" type="text" placeholder="$"/></div>
@@ -223,10 +237,10 @@
             <div><label for="contract">Contractor/Facilitator</label><input id="contract" type="text" placeholder="$"/></div>
           </div>
           <label for="av">AV/Other</label><input id="av" type="text" placeholder="$ or notes"/>
-        </details>
+        </div>
 
-        <details>
-          <summary>Step 7 — Action matrix</summary>
+        <div class="step-pane" id="step7" role="tabpanel" hidden aria-hidden="true">
+          <h3>Step 7 — Action matrix</h3>
           <div class="help">Add rows, then include dates, actions, roles, and methods.</div>
           <table id="am-table">
             <thead><tr><th>Date</th><th>Action</th><th>Responsibility</th><th>When</th><th>Method</th></tr></thead>
@@ -236,16 +250,16 @@
             <button class="btn ghost" id="am-add">+ Add row</button>
             <button class="btn ghost" id="am-clear">Clear</button>
           </div>
-        </details>
+        </div>
 
-        <details>
-          <summary>Step 8 — Implementation tracking</summary>
+        <div class="step-pane" id="step8" role="tabpanel" hidden aria-hidden="true">
+          <h3>Step 8 — Implementation tracking</h3>
           <label for="tracking">Tracking notes</label>
           <textarea id="tracking" placeholder="Cadence, ownership, dashboards."></textarea>
-        </details>
+        </div>
 
-        <details>
-          <summary>Step 9 — Measurement plan</summary>
+        <div class="step-pane" id="step9" role="tabpanel" hidden aria-hidden="true">
+          <h3>Step 9 — Measurement plan</h3>
           <label>Outputs (products/channels)</label>
           <div id="outputsList" class="taglist"></div>
           <div class="tagadd">
@@ -269,13 +283,13 @@
 
           <label for="measurementNotes" style="margin-top:10px">Measurement notes</label>
           <textarea id="measurementNotes" placeholder="Baselines, targets, data sources, cadence."></textarea>
-        </details>
+        </div>
 
-        <details>
-          <summary>Step 10 — Evaluation and feedback</summary>
+        <div class="step-pane" id="step10" role="tabpanel" hidden aria-hidden="true">
+          <h3>Step 10 — Evaluation and feedback</h3>
           <label for="evaluation">Evaluation plan</label>
           <textarea id="evaluation" placeholder="Methods, timing, follow-on research and updates."></textarea>
-        </details>
+        </div>
 
         <div class="btnbar">
           <button class="btn" id="generate">Generate plan</button>
@@ -494,6 +508,9 @@
 
       evaluation: document.getElementById('evaluation'),
 
+      stepper: document.getElementById('stepper'),
+      progress: document.getElementById('progress'),
+
       generate: document.getElementById('generate'),
       save: document.getElementById('save'),
       load: document.getElementById('load'),
@@ -538,6 +555,46 @@
     document.querySelectorAll('button[data-add]').forEach(btn=>{
       btn.addEventListener('click', ()=> addCustom(btn.getAttribute('data-add')));
     });
+
+    const stepButtons = Array.from(els.stepper.querySelectorAll('button'));
+    const stepPanes = Array.from(document.querySelectorAll('.step-pane'));
+    let currentStep = 1;
+
+    function showStep(n){
+      currentStep = n;
+      stepPanes.forEach((pane, idx)=>{
+        const active = idx === n - 1;
+        if(active){
+          pane.hidden = false;
+          pane.removeAttribute('aria-hidden');
+        } else {
+          pane.hidden = true;
+          pane.setAttribute('aria-hidden','true');
+        }
+      });
+      stepButtons.forEach((btn, idx)=>{
+        const selected = idx === n - 1;
+        btn.setAttribute('aria-selected', selected ? 'true' : 'false');
+        btn.tabIndex = selected ? 0 : -1;
+      });
+      els.progress.textContent = `Step ${currentStep} of 10 — ${Math.round((currentStep/10)*100)} percent complete`;
+    }
+
+    stepButtons.forEach((btn, idx)=>{
+      btn.addEventListener('click', ()=> showStep(idx + 1));
+      btn.addEventListener('keydown', e=>{
+        if(e.key === 'ArrowRight'){
+          const next = (idx + 1) % stepButtons.length;
+          stepButtons[next].focus();
+          showStep(next + 1);
+        } else if(e.key === 'ArrowLeft'){
+          const prev = (idx + stepButtons.length - 1) % stepButtons.length;
+          stepButtons[prev].focus();
+          showStep(prev + 1);
+        }
+      });
+    });
+    showStep(1);
 
     const activateTab = (which) => {
       const staff = document.getElementById('panel-inputs');


### PR DESCRIPTION
## Summary
- introduce tab-based stepper with progress announcements for each R-PIE step
- support arrow-key navigation between steps and hide inactive panes from screen readers

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b91e27848328ba8fa318d5f66390