### PR TITLE
Remove unused card variable from rpie page

### DIFF
--- a/rpie.html
+++ b/rpie.html
@@ -11,7 +11,6 @@
       --brand-black:#030000;
       --ink:#0f1220;
       --muted:#6b7280;
-      --card:#ffffff;
       --ok:#16a34a;
       --warn:#d97706;
       --err:#b91c1c;


### PR DESCRIPTION
## Summary
- drop `--card` CSS variable from R-PIE planner page root block as it was unused

## Testing
- `rg -n -- '--card' rpie.html`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cd39a8a48328be081a5df4e0dfb1