### PR TITLE
Add responsive breakpoints for various screen widths

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,23 @@
   #onboardSpotlight{position:absolute;border:2px solid #fff;border-radius:8px;pointer-events:none}
   .onboard .tip{background:#fff;color:#000;padding:20px;border-radius:12px;max-width:90%;text-align:center}
   body.noscroll{overflow:hidden}
+
+  /* ==== Responsive tweaks ==== */
+  @media (min-width:1440px){
+    .shell{max-width:1400px}
+  }
+  @media (max-width:1024px){
+    .grid-3{grid-template-columns:repeat(2,minmax(0,1fr))}
+  }
+  @media (max-width:768px){
+    .row{flex-direction:column}
+    .grid-3,.grid-2{grid-template-columns:1fr}
+    .hamburger{display:flex}
+  }
+  @media (max-width:360px){
+    .topbar{flex-direction:column;align-items:flex-start}
+    .topbar h1{font-size:16px}
+  }
 </style>
 </head>
 <body>

--- a/rpie.html
+++ b/rpie.html
@@ -42,7 +42,10 @@
     }
     .tab.active{border-color:var(--brand-red);outline:2px solid rgba(239,51,64,.15)}
     .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;align-items:start;}
-    @media (max-width:980px){.grid{grid-template-columns:1fr}}
+    @media (min-width:1440px){.wrap{max-width:1400px}}
+    @media (max-width:1024px){.grid{grid-template-columns:1fr}}
+    @media (max-width:768px){header{flex-direction:column;align-items:flex-start}.row{flex-direction:column}.tabs{flex-direction:column}}
+    @media (max-width:360px){.brand{flex-direction:column;align-items:flex-start}.badge{font-size:14px}}
     .card{
       background:rgba(255,255,255,.85);backdrop-filter: blur(8px);
       border:1px solid #e5e7eb;border-radius:var(--radius);


### PR DESCRIPTION
## Summary
- Add responsive media queries to `index.html` for 360px, 768px, 1024px, and 1440px widths
- Extend `rpie.html` stylesheet with corresponding breakpoints

## Testing
- `npm test` *(fails: Could not read package.json)*
- Attempted to install and run a browser for layout verification *(environment lacks snapd, cannot run Chromium/Firefox)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cd38d66083288a4eb0bcdb853272