### PR TITLE
Optimize hidden sections with content-visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
   .kpi h4{margin:0 0 6px 0; font-size:13px; color:#27314e}
   .kpi .big{font-size:24px; font-weight:900; color:#0b1733}
   .hide{display:none !important}
+  #screenViewer,#screenStaff,#screenAdmin,#modKLE,#modMedia,#modSocial,#modBrand,#modChecklist,#modRpie{content-visibility:auto;contain-intrinsic-size:0 500px;}
   /* drawer */
   .drawer{position:fixed; inset:0; display:none; z-index:1000}
   .drawer.open{display:block}


### PR DESCRIPTION
## Summary
- Avoid rendering off-screen sections (#screenViewer, #screenStaff, #screenAdmin, modules) until needed using `content-visibility:auto` and `contain-intrinsic-size:0 500px`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node test_visibility.js` *(fails: browser process failed to launch; chromium snap required)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c904d3188328a8e3113273a16617