### PR TITLE
cache AI DOM elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -1163,9 +1163,12 @@ window.addEventListener('scroll',()=>{ if(!onboardOverlay.classList.contains('hi
 </div>
 
 <script>
+const aiPromptEl=document.getElementById('aiPrompt');
+const aiProviderEl=document.getElementById('aiProvider');
+const aiOutputEl=document.getElementById('aiOutput');
 async function callAI(){
-  const prompt=document.getElementById('aiPrompt').value.trim();
-  const provider=document.getElementById('aiProvider').value;
+  const prompt=aiPromptEl.value.trim();
+  const provider=aiProviderEl.value;
   const providerNames={openai:'OpenAI',gemini:'Gemini',camogpt:'CamoGPT',asksage:'AskSage'};
   const key=db.apiKeys?.[provider]?.trim();
   if(!key) return alert(providerNames[provider]+" API key not set by Admin.");
@@ -1175,22 +1178,22 @@ async function callAI(){
     if(provider==='openai'){
       res=await fetch('https://api.openai.com/v1/chat/completions',{method:'POST',headers:{'Authorization':`Bearer ${key}`,'Content-Type':'application/json'},body:JSON.stringify({model:'gpt-4',messages:[{role:'user',content:prompt}]})});
       data=await res.json();
-      document.getElementById('aiOutput').textContent=data.choices?.[0]?.message?.content||'No response';
+      aiOutputEl.textContent=data.choices?.[0]?.message?.content||'No response';
     }else if(provider==='gemini'){
       res=await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${key}`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({contents:[{parts:[{text:prompt}]}]})});
       data=await res.json();
-      document.getElementById('aiOutput').textContent=data.candidates?.[0]?.content?.parts?.[0]?.text||'No response';
+      aiOutputEl.textContent=data.candidates?.[0]?.content?.parts?.[0]?.text||'No response';
     }else if(provider==='camogpt'){
       res=await fetch('https://api.camogpt.com/v1/chat/completions',{method:'POST',headers:{'Authorization':`Bearer ${key}`,'Content-Type':'application/json'},body:JSON.stringify({model:'camo-gpt',messages:[{role:'user',content:prompt}]})});
       data=await res.json();
-      document.getElementById('aiOutput').textContent=data.choices?.[0]?.message?.content||'No response';
+      aiOutputEl.textContent=data.choices?.[0]?.message?.content||'No response';
     }else if(provider==='asksage'){
       res=await fetch('https://api.asksage.ai/v1/chat/completions',{method:'POST',headers:{'Authorization':`Bearer ${key}`,'Content-Type':'application/json'},body:JSON.stringify({model:'sage',messages:[{role:'user',content:prompt}]})});
       data=await res.json();
-      document.getElementById('aiOutput').textContent=data.choices?.[0]?.message?.content||'No response';
+      aiOutputEl.textContent=data.choices?.[0]?.message?.content||'No response';
     }
   }catch(err){
-    document.getElementById('aiOutput').textContent='Error: '+err.message;
+    aiOutputEl.textContent='Error: '+err.message;
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- cache references to AI prompt, provider, and output elements
- update callAI to use cached DOM nodes instead of repeated lookups

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c9026424832886d86ab0843d7445