### PR TITLE
feat: add accessible tooltip theme variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
     --accent2: linear-gradient(135deg,#ff6ec4 0%, #7873f5 100%); /* admin/menu */
     --accent3: linear-gradient(135deg,#f6d365 0%, #fda085 100%); /* goals */
     --accent4: linear-gradient(135deg,#42e695 0%, #3bb2b8 100%); /* staff cards */
+    --tooltip-bg: #f9fafb; /* light tooltip background */
+    --tooltip-fg: #111;    /* dark tooltip text */
   }
   *{box-sizing:border-box}
   html,body{height:100%}
@@ -88,6 +90,11 @@
   .grad3{background:var(--accent3)}
   .grad4{background:linear-gradient(135deg,#00e5ff,#7c4dff)}
   .grad5{background:linear-gradient(135deg,#ff8a8a,#ffd06a)}
+  .tooltip{position:relative;cursor:help}
+  .tooltip:hover::after,
+  .tooltip:focus::after{content:attr(data-tip);position:absolute;left:50%;bottom:100%;transform:translate(-50%,-4px);background:var(--tooltip-bg);color:var(--tooltip-fg);padding:4px 8px;border-radius:4px;font-size:12px;white-space:nowrap;box-shadow:0 2px 6px rgba(0,0,0,.3);z-index:1000}
+  .tooltip:hover::before,
+  .tooltip:focus::before{content:"";position:absolute;left:50%;bottom:100%;transform:translate(-50%,2px);border:6px solid transparent;border-top-color:var(--tooltip-bg)}
 </style>
 </head>
 <body>

--- a/rpie.html
+++ b/rpie.html
@@ -16,6 +16,8 @@
       --warn:#d97706;
       --err:#b91c1c;
       --radius:14px;
+      --tooltip-bg:#111; /* dark tooltip background */
+      --tooltip-fg:#fff; /* light tooltip text */
     }
     html,body{height:100%}
     body{
@@ -94,6 +96,11 @@
     .tagadd{display:flex;gap:8px;margin-top:8px}
     .tagadd input{flex:1}
     .footer-note{font-size:12px;color:var(--muted);margin-top:10px}
+    .tooltip{position:relative;cursor:help}
+    .tooltip:hover::after,
+    .tooltip:focus::after{content:attr(data-tip);position:absolute;left:50%;bottom:100%;transform:translate(-50%,-4px);background:var(--tooltip-bg);color:var(--tooltip-fg);padding:4px 8px;border-radius:4px;font-size:12px;white-space:nowrap;box-shadow:0 2px 6px rgba(0,0,0,.2);z-index:1000}
+    .tooltip:hover::before,
+    .tooltip:focus::before{content:"";position:absolute;left:50%;bottom:100%;transform:translate(-50%,2px);border:6px solid transparent;border-top-color:var(--tooltip-bg)}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add `--tooltip-bg` and `--tooltip-fg` CSS variables to dark and light themes
- style tooltip component using new variables for consistent contrast

## Testing
- `node -e 'function lum(r,g,b){r/=255;g/=255;b/=255;[r,g,b]=[r,g,b].map(v=>v<=0.03928?v/12.92:Math.pow((v+0.055)/1.055,2.4));return 0.2126*r+0.7152*g+0.0722*b;} function contrast(hex1,hex2){function h(hx){hx=hx.replace("#","");return [parseInt(hx.substr(0,2),16),parseInt(hx.substr(2,2),16),parseInt(hx.substr(4,2),16)];} const L1=lum(...h(hex1)); const L2=lum(...h(hex2)); return (Math.max(L1,L2)+0.05)/(Math.min(L1,L2)+0.05);} console.log("text vs tooltip (index)",contrast("#111111","#f9fafb")); console.log("text vs tooltip (rpie)",contrast("#ffffff","#111111"));'`
- `node -e 'function lum(r,g,b){r/=255;g/=255;b/=255;[r,g,b]=[r,g,b].map(v=>v<=0.03928?v/12.92:Math.pow((v+0.055)/1.055,2.4));return 0.2126*r+0.7152*g+0.0722*b;} function contrast(hex1,hex2){function h(hx){hx=hx.replace("#","");return [parseInt(hx.substr(0,2),16),parseInt(hx.substr(2,2),16),parseInt(hx.substr(4,2),16)];} const L1=lum(...h(hex1)); const L2=lum(...h(hex2)); return (Math.max(L1,L2)+0.05)/(Math.min(L1,L2)+0.05);} console.log("tooltip vs page (index)",contrast("#f9fafb","#0e0f1a")); console.log("tooltip vs page (rpie)",contrast("#111111","#fafafa"));'`

------
https://chatgpt.com/codex/tasks/task_e_68a0c21bc19c83288dec773cf3962dc8