### PR TITLE
Clear registration inputs after sign up

### DIFF
--- a/index.html
+++ b/index.html
@@ -1435,6 +1435,9 @@ async function callAI(){
       { emailRedirectTo: window.location.origin }
     );
     $("status").textContent = error ? `Signup error: ${error.message}` : "Check your email to confirm.";
+    $("su-email").value = "";
+    $("su-pass").value = "";
+    $("su-pass-confirm").value = "";
   };
 
   window.nwwSignIn = async () => {


### PR DESCRIPTION
## Summary
- Clear signup form fields after registration attempt so success message isn't missed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23b760cb88328a3c6c49d4e19ee69