### PR TITLE
Enable viewer progress view and broaden menu access

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
   </section>
 
   <!-- VIEWER -->
-  <section id="screenViewer" class="hide staff-only">
+  <section id="screenViewer" class="hide">
     <div class="row" style="margin-top:18px">
       <div class="col">
         <div class="card">
@@ -689,7 +689,7 @@ inputLoadProgress.addEventListener('change', e=>{
   fr.readAsText(f); inputLoadProgress.value='';
 });
 function show(which){
-  const hideHamburger=['unit','role','viewer','staffAuth','chiefAuth','adminAuth'];
+  const hideHamburger=['unit','role','viewer'];
   btnHamburger.style.display = hideHamburger.includes(which) ? 'none' : '';
   ['screenUnit','screenRole','screenAuth','screenViewer','screenStaff','screenChief','screenAdmin','modKLE','modMedia','modSocial','modBrand','modChecklist','modRpie'].forEach(id=> $('#'+id).classList.add('hide'));
   $('#askAIModule')?.classList.add('hide');


### PR DESCRIPTION
## Summary
- Allow unauthenticated viewers to see unit progress by removing staff-only restriction
- Show hamburger navigation for staff, PAO chief, and admin by limiting hide logic to unit, role, and viewer screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a26ebd89088328b42e3db4edf75b5f