### PR TITLE
Remove admin sign-up option

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,14 +156,6 @@
     <!-- Admin Supabase auth -->
     <div id="adminAuth" class="hide">
       <section>
-        <h3>Sign up</h3>
-        <input id="su-email" type="email" placeholder="Email" required />
-        <input id="su-pass" type="password" placeholder="Password" required />
-        <input id="su-pass-confirm" type="password" placeholder="Confirm Password" required />
-        <button onclick="nwwSignUp()">Create account</button>
-      </section>
-
-      <section>
         <h3>Sign in</h3>
         <input id="si-email" type="email" placeholder="Email" required />
         <input id="si-pass" type="password" placeholder="Password" required />
@@ -1609,25 +1601,7 @@ async function callAI(){
 
   const $ = (id) => document.getElementById(id);
 
-  // Sign up / Sign in / Sign out
-  window.nwwSignUp = async () => {
-    const email = $("su-email").value;
-    const password = $("su-pass").value;
-    const confirm = $("su-pass-confirm").value;
-    if (password !== confirm) {
-      $("status").textContent = "Passwords do not match.";
-      return;
-    }
-    const { error } = await supabase.auth.signUp(
-      { email, password },
-      { emailRedirectTo: window.location.origin }
-    );
-    $("status").textContent = error ? `Signup error: ${error.message}` : "Check your email to confirm.";
-    $("su-email").value = "";
-    $("su-pass").value = "";
-    $("su-pass-confirm").value = "";
-  };
-
+  // Sign in / Sign out
   window.nwwSignIn = async () => {
     const email = $("si-email").value;
     const password = $("si-pass").value;


### PR DESCRIPTION
## Summary
- remove admin sign-up form
- drop sign-up logic, leaving only sign in/out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a27a6c5344832887678508ee485c52