### PR TITLE
Disable admin sign-up via Supabase sign-in

### DIFF
--- a/index.html
+++ b/index.html
@@ -1605,7 +1605,11 @@ async function callAI(){
   window.nwwSignIn = async () => {
     const email = $("si-email").value;
     const password = $("si-pass").value;
-    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    const { error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+      options: { shouldCreateUser: false }
+    });
     $("status").textContent = error ? `Signin error: ${error.message}` : "Signed in.";
     refreshAuthUI();
     if(!error && window.role==='admin'){ buildAdmin(); show('admin'); }


### PR DESCRIPTION
## Summary
- Ensure admin sign-in cannot create new accounts by passing `shouldCreateUser: false` to Supabase `signInWithPassword`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27bdaad0883289e39f13ab464cbfc