### PR TITLE
Fix admin navigation after Supabase sign-in

### DIFF
--- a/index.html
+++ b/index.html
@@ -1632,7 +1632,10 @@ async function callAI(){
     });
     $("status").textContent = error ? `Signin error: ${error.message}` : "Signed in.";
     const prof = await refreshAuthUI();
-    if(!error && prof?.role==='admin'){ buildAdmin(); window.show('admin'); }
+    // If the profile fetch fails, fall back to the role selected on the role
+    // screen so admins can still access the admin view after signing in.
+    const isAdmin = prof?.role === 'admin' || (!prof && role === 'admin');
+    if (!error && isAdmin) { buildAdmin(); window.show('admin'); }
   };
 
   async function refreshAuthUI() {


### PR DESCRIPTION
## Summary
- Handle missing profile when determining admin role
- Ensure admin users are routed to the admin view after signing in

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a28cafb4e88328878286038aa63d2d