### PR TITLE
Ensure user-selected admin role takes precedence

### DIFF
--- a/index.html
+++ b/index.html
@@ -1634,7 +1634,7 @@ async function callAI(){
     const prof = await refreshAuthUI();
     // If the profile fetch fails, fall back to the role selected on the role
     // screen so admins can still access the admin view after signing in.
-    const isAdmin = prof?.role === 'admin' || (!prof && role === 'admin');
+    const isAdmin = role === "admin" || prof?.role === "admin";
     if (!error && isAdmin) { buildAdmin(); window.show('admin'); }
   };
 
@@ -1657,7 +1657,7 @@ async function callAI(){
       .eq("id", uid)
       .single();
 
-    role = prof?.role || role;
+    role = role || prof?.role;
     document.body.classList.toggle("is-admin", role === "admin");
     $("status").textContent = `Signed in as ${prof?.email || session.user.email}`;
     resetIdle();


### PR DESCRIPTION
## Summary
- Prioritize the selected role over profile role when refreshing auth state
- Determine admin access if either the selected role or profile role is admin

## Testing
- `npm test`
- `node - <<'NODE'
const { JSDOM } = require('jsdom');
const dom = new JSDOM(`<!DOCTYPE html><body><div id="status"></div><input id="si-email"><input id="si-pass"><div id="screenAdmin" class="hide"></div></body>`);
const window = dom.window;
const document = window.document;
const $ = (id) => document.getElementById(id);
let lastScreen = null;
window.show = (which) => { lastScreen = which; };
let buildAdminCalled = false;
function buildAdmin() { buildAdminCalled = true; }
function resetIdle() {}
let role = 'admin';
let idleTimer = null;
const supabase = {
  auth: {
    signInWithPassword: async () => ({ error: null }),
    getSession: async () => ({ data: { session: { user: { id: '123', email: 'user@example.com' } } } }),
    signOut: async () => {}
  },
  from: () => ({
    select: () => ({
      eq: () => ({
        single: async () => ({ data: { role: 'viewer', email: 'user@example.com' } })
      })
    })
  })
};
async function refreshAuthUI() {
  const { data: { session } } = await supabase.auth.getSession();
  const authed = !!session?.user;
  document.body.classList.toggle("is-authed", authed);
  if (!authed) {
    document.body.classList.remove("is-admin");
    role=null;
    $("status").textContent = "Not signed in";
    clearTimeout(idleTimer);
    return null;
  }
  const uid = session.user.id;
  const { data: prof } = await supabase.from("profiles")
    .select("role, full_name, email")
    .eq("id", uid)
    .single();
  role = role || prof?.role;
  document.body.classList.toggle("is-admin", role === "admin");
  $("status").textContent = `Signed in as ${prof?.email || session.user.email}`;
  resetIdle();
  return prof;
}
async function nwwSignIn() {
  const email = $("si-email").value;
  const password = $("si-pass").value;
  const { error } = await supabase.auth.signInWithPassword({
    email,
    password,
    options: { shouldCreateUser: false }
  });
  $("status").textContent = error ? `Signin error: ${error.message}` : "Signed in.";
  const prof = await refreshAuthUI();
  const isAdmin = role === "admin" || prof?.role === "admin";
  if (!error && isAdmin) { buildAdmin(); window.show('admin'); }
}
$("si-email").value = "user@example.com";
$("si-pass").value = "password";
(async () => {
  await nwwSignIn();
  console.log('status:', $("status").textContent);
  console.log('lastScreen:', lastScreen);
  console.log('buildAdminCalled:', buildAdminCalled);
})();
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a29143e4c88328932026c840e04973