### PR TITLE
Fix chief assignment and admin login issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
         <h3>Sign in</h3>
         <input id="si-email" type="email" placeholder="Email" required />
         <input id="si-pass" type="password" placeholder="Password" required />
-        <button onclick="nwwSignIn()">Sign in</button>
+        <button type="button" onclick="nwwSignIn()">Sign in</button>
       </section>
 
       <pre id="status">Not signed in</pre>
@@ -1246,7 +1246,9 @@ $('#btnAdminAddChief').onclick=()=>{
   chiefs.push({id, name, pin});
   saveChiefs(chiefs);
   const prevUnit=currentUnit;
-  const data=load(unit); data.chiefId=id; save();
+  db=load(unit);
+  db.chiefId=id;
+  save();
   db=load(prevUnit);
   $('#adminNewChief').value=''; $('#adminNewChiefPIN').value='';
   buildAdmin();


### PR DESCRIPTION
## Summary
- Ensure new chief assignments persist by saving to the selected unit's data
- Prevent admin sign-in button from submitting implicitly to avoid stuck sign-in

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a379060d208328b97ba9516071016e