### PR TITLE
refactor: centralize AI API keys under admin role

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a self-contained web application that:
 
 ✅ Tracks staff metrics (outputs, outcomes, outtakes)  
 ✅ Stores user data and API keys **locally** in the browser (`localStorage`)  
-✅ Lets PAO chiefs enter API keys for **OpenAI, Gemini, CamoGPT, and AskSage**
+✅ Lets admins enter API keys for **OpenAI, Gemini, CamoGPT, and AskSage**
 ✅ Allows staff and PAO chiefs to **ask AI** using the selected provider
 ✅ No backend required
 

--- a/rpie.html
+++ b/rpie.html
@@ -721,7 +721,7 @@ Produce a complete, structured plan with clear headings and a table for the Acti
     }
 
     async function callOpenAI(prompt){
-      const key = window.parent?.db?.apiKeys?.openai || '';
+      const key = window.parent?.aiApiKeys?.openai || '';
       if(!key){ throw new Error('API key required'); }
       const res = await fetch('https://api.openai.com/v1/chat/completions',{
         method:'POST',


### PR DESCRIPTION
## Summary
- use global admin AI keys in RPIE module
- document that admins manage AI provider keys

## Testing
- `npm run test:tooltip`


------
https://chatgpt.com/codex/tasks/task_e_68a3d6efca60832899eb195990d3f2ef