### PR TITLE
Fix password reset flow to require recovery session

### DIFF
--- a/index.html
+++ b/index.html
@@ -1679,9 +1679,11 @@ async function callAI(){
   window.requestPasswordReset = async () => {
     const email = $("si-email").value;
     if (!email) { alert("Enter email to reset password"); return; }
-    const { error } = await supabase.auth.resetPasswordForEmail(email);
+    const { origin, pathname } = window.location;
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: origin + pathname
+    });
     $("status").textContent = error ? `Reset error: ${error.message}` : "Check email for reset link";
-    if (!error) { window.show('adminReset'); }
   };
 
   window.finishPasswordReset = async () => {


### PR DESCRIPTION
## Summary
- Avoid showing the reset password form immediately after requesting a reset
- Users now only see the reset form after following the recovery email link, preventing "Auth session missing" errors
- Redirect password reset emails back to the app to avoid 404 after verification

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f082db2883288b4c933e6cf2d0d1