### PR TITLE
Persist admin sign-in status message

### DIFF
--- a/index.html
+++ b/index.html
@@ -1670,17 +1670,22 @@ async function callAI(){
   window.nwwSignIn = async () => {
     const email = $("si-email").value;
     const password = $("si-pass").value;
+    $("status").textContent = "Signing you in, please wait";
     const { error } = await supabase.auth.signInWithPassword({
       email,
       password,
       options: { shouldCreateUser: false }
     });
-    $("status").textContent = error ? `Signin error: ${error.message}` : "Signed in.";
+    if (error) {
+      $("status").textContent = `Signin error: ${error.message}`;
+      return;
+    }
+    $("status").textContent = "Signed in.";
     const prof = await refreshAuthUI();
     // If the profile fetch fails, fall back to the role selected on the role
     // screen so admins can still access the admin view after signing in.
     const isAdmin = role === "admin" || prof?.role === "admin";
-    if (!error && isAdmin) { buildAdmin(); window.show('admin'); }
+    if (isAdmin) { buildAdmin(); window.show('admin'); }
   };
 
   window.nwwSignUp = async () => {


### PR DESCRIPTION
## Summary
- Keep admin sign-in status visible until the user takes another action
- Show a "Signing you in, please wait" message while authentication processes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a44e34bf1c83288fa3b7acfb5856a6