### PR TITLE
feat: allow unit selection during registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@
       <section style="margin-top:16px">
         <h3>Sign up</h3>
         <input id="su-email" type="email" placeholder="Email" required />
-        <input id="su-unit" type="text" placeholder="Unit" required />
+        <select id="su-unit" class="input" required></select>
         <input id="su-pass" type="password" placeholder="Password" required />
         <input id="su-confirm" type="password" placeholder="Confirm password" required />
         <button type="button" onclick="nwwSignUp()">Sign up</button>
@@ -878,6 +878,8 @@ function show(which, isBack=false){
     $('#adminAuth').classList.remove('hide');
     $('#staffAuth').classList.add('hide');
     $('#chiefAuth').classList.add('hide');
+    if (typeof reloadUnits === 'function') reloadUnits();
+    else populateUnitSelect('#su-unit');
     return;
   }
   if(which==='adminReset'){
@@ -1801,11 +1803,15 @@ async function callAI(){
 
   window.nwwSignUp = async () => {
     const email = $("su-email").value.trim().toLowerCase();
-    const unit = $("su-unit").value.trim();
+    const unit = $("su-unit").value;
     const password = $("su-pass").value;
     const confirm = $("su-confirm").value;
     if (password !== confirm) {
       $("status").textContent = "Passwords do not match";
+      return;
+    }
+    if (!unit) {
+      $("status").textContent = "Select a unit";
       return;
     }
     const displayName = email.split('@')[0];

--- a/paoweb-supabase.js
+++ b/paoweb-supabase.js
@@ -31,12 +31,13 @@ const $ = (s) => document.querySelector(s);
 const toInt = (v, d=0) => { const n = parseInt(v,10); return Number.isFinite(n)?n:d; };
 
 async function reloadUnits(){
-  const sel = $("#unitSel");
-  if(!sel) return;
+  const sels = ["#unitSel", "#su-unit"].map(s => $(s)).filter(Boolean);
+  if(!sels.length) return;
   try{
     const { data, error } = await sb.rpc("list_units");
     if(error) throw error;
-    sel.innerHTML = (data||[]).map(u=>`<option value="${u.id??u.code}">${u.name??u.unit_name??u.code}</option>`).join("");
+    const opts = (data||[]).map(u=>`<option value="${u.id??u.code}">${u.name??u.unit_name??u.code}</option>`).join("");
+    sels.forEach(sel => sel.innerHTML = opts);
   }catch(err){
     console.error("list_units failed", err);
   }


### PR DESCRIPTION
## Summary
- Replace unit text field with dropdown during sign-up
- Load available units into dropdown for admin auth
- Fetch units for both unit selector and sign-up using Supabase RPC

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4d5a4c4ec83288dc780c8cae8cfd2