### PR TITLE
Fix email normalization for sign in

### DIFF
--- a/index.html
+++ b/index.html
@@ -1779,7 +1779,7 @@ async function callAI(){
 
   // Sign in
   window.nwwSignIn = async (email, password) => {
-    email = email || $("si-email").value;
+    email = (email || $("si-email").value).trim().toLowerCase();
     password = password || $("si-pass").value;
     $("status").textContent = "Signing you in, please wait";
     const { error } = await supabase.auth.signInWithPassword({


### PR DESCRIPTION
## Summary
- Normalize sign-in email by trimming whitespace and forcing lowercase to avoid credential mismatches

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a506fced0c8328a5b77d6dbdc5209d