### PR TITLE
Use Supabase units in unit pickers

### DIFF
--- a/index.html
+++ b/index.html
@@ -780,7 +780,15 @@ async function loadEntriesFromSupabase(){
   }catch(err){ console.error('Supabase load failed', err); }
 }
 
-function buildUnitPicker(){ populateUnitSelect('#unitSel'); }
+function buildUnitPicker(){
+  // Prefer Supabase-provided units when available
+  if (typeof reloadUnits === 'function') {
+    reloadUnits();
+  } else {
+    // Fallback to local storage units (offline mode)
+    populateUnitSelect('#unitSel');
+  }
+}
 
 /* ================= HELPERS ================= */
 const $=s=>document.querySelector(s); const $$=s=>Array.from(document.querySelectorAll(s));

--- a/paoweb-supabase.js
+++ b/paoweb-supabase.js
@@ -269,8 +269,12 @@ async function addTemplate(form){
 
 // ---------- Bind UI ----------
 function bindUI(){
-  window.buildUnitPicker = reloadUnits;
-  reloadUnits();
+  // Populate unit selectors from Supabase when the page loads
+  if (typeof window.buildUnitPicker === 'function') {
+    window.buildUnitPicker();
+  } else {
+    reloadUnits();
+  }
 
   // Admin sign-in
   $("#admin-signin")?.addEventListener("click", adminSignIn);


### PR DESCRIPTION
## Summary
- Prefer Supabase unit list for unit pickers and fall back to local storage
- Populate unit selectors from Supabase on page load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a52a9213c08328a40a4c2f6c2245c6