### PR TITLE
fix: display Supabase units without RPC

### DIFF
--- a/paoweb-supabase.js
+++ b/paoweb-supabase.js
@@ -34,19 +34,44 @@ async function reloadUnits(){
   const sels = ["#unitSel", "#su-unit"].map(s => $(s)).filter(Boolean);
   if(!sels.length) return;
   try{
-    const { data, error } = await sb.rpc("list_units");
-    if(error) throw error;
-    const opts = (data||[]).map(u=>`<option value="${u.id??u.code}">${u.name??u.unit_name??u.code}</option>`).join("");
+    let units = [];
+
+    // Try RPC first; fall back to direct table queries if it fails
+    try {
+      const { data, error } = await sb.rpc("list_units");
+      if (error) throw error;
+      units = data || [];
+    } catch (_err) {
+      try {
+        const { data, error } = await sb
+          .from("unit")
+          .select("id, name, unit_name, code")
+          .order("name", { ascending: true });
+        if (error) throw error;
+        units = data || [];
+      } catch (__err) {
+        const { data, error } = await sb
+          .from("units")
+          .select("id, name, unit_name, code")
+          .order("name", { ascending: true });
+        if (error) throw error;
+        units = data || [];
+      }
+    }
+
+    const opts = units
+      .map(u => `<option value="${u.id ?? u.code}">${u.name ?? u.unit_name ?? u.code}</option>`)
+      .join("");
     sels.forEach(sel => {
       sel.innerHTML = opts;
       if (sel.id === 'su-unit') {
         const defName = 'Walla Walla District';
-        const def = (data||[]).find(u => (u.name ?? u.unit_name ?? u.code) === defName);
+        const def = units.find(u => (u.name ?? u.unit_name ?? u.code) === defName);
         if (def) sel.value = def.id ?? def.code;
       }
     });
   }catch(err){
-    console.error("list_units failed", err);
+    console.error("load units failed", err);
   }
 }
 


### PR DESCRIPTION
## Summary
- Fallback to direct `unit`/`units` table queries when `list_units` RPC isn't available
- Improve logging for unit loading errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a52cbbb8bc8328abd2472404380f94