### PR TITLE
Handle missing Supabase units

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,6 +787,7 @@ function buildUnitPicker(){
   } else {
     // Fallback to local storage units (offline mode)
     populateUnitSelect('#unitSel');
+    populateUnitSelect('#su-unit');
   }
 }
 

--- a/paoweb-supabase.js
+++ b/paoweb-supabase.js
@@ -59,19 +59,28 @@ async function reloadUnits(){
       }
     }
 
-    const opts = units
-      .map(u => `<option value="${u.id ?? u.code}">${u.name ?? u.unit_name ?? u.code}</option>`)
-      .join("");
-    sels.forEach(sel => {
-      sel.innerHTML = opts;
-      if (sel.id === 'su-unit') {
-        const defName = 'Walla Walla District';
-        const def = units.find(u => (u.name ?? u.unit_name ?? u.code) === defName);
-        if (def) sel.value = def.id ?? def.code;
-      }
-    });
+    if (units.length) {
+      const opts = units
+        .map(u => `<option value="${u.id ?? u.code}">${u.name ?? u.unit_name ?? u.code}</option>`)
+        .join("");
+      sels.forEach(sel => {
+        sel.innerHTML = opts;
+        if (sel.id === 'su-unit') {
+          const defName = 'Walla Walla District';
+          const def = units.find(u => (u.name ?? u.unit_name ?? u.code) === defName);
+          if (def) sel.value = def.id ?? def.code;
+        }
+      });
+    } else if (typeof populateUnitSelect === 'function') {
+      populateUnitSelect('#unitSel');
+      populateUnitSelect('#su-unit');
+    }
   }catch(err){
     console.error("load units failed", err);
+    if (typeof populateUnitSelect === 'function') {
+      populateUnitSelect('#unitSel');
+      populateUnitSelect('#su-unit');
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- fallback to locally stored units when Supabase unit list can't be loaded
- ensure both home and sign-up screens populate unit selects in offline mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a52ef448848328977cfda969c07a85