### PR TITLE
Add Supabase AI key storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1366,13 +1366,25 @@ function buildAdmin(){
     $('#adminApiKeyGemini').value = aiApiKeys.gemini || '';
     $('#adminApiKeyCamogpt').value = aiApiKeys.camogpt || '';
     $('#adminApiKeyAsksage').value = aiApiKeys.asksage || '';
-    $('#btnAdminSaveAiKeys').onclick = () => {
+    $('#btnAdminSaveAiKeys').onclick = async () => {
       aiApiKeys.openai = $('#adminApiKeyOpenAI').value.trim();
       aiApiKeys.gemini = $('#adminApiKeyGemini').value.trim();
       aiApiKeys.camogpt = $('#adminApiKeyCamogpt').value.trim();
       aiApiKeys.asksage = $('#adminApiKeyAsksage').value.trim();
       saveAiApiKeys();
-      alert('AI API Keys saved');
+      const unit_id = CURRENT?.unit_id;
+      try {
+        await Promise.all([
+          PAOWeb.saveAiKey({ unit_id, provider:'openai', api_key: aiApiKeys.openai, model:null, enabled:!!aiApiKeys.openai }),
+          PAOWeb.saveAiKey({ unit_id, provider:'gemini', api_key: aiApiKeys.gemini, model:null, enabled:!!aiApiKeys.gemini }),
+          PAOWeb.saveAiKey({ unit_id, provider:'camogpt', api_key: aiApiKeys.camogpt, model:null, enabled:!!aiApiKeys.camogpt }),
+          PAOWeb.saveAiKey({ unit_id, provider:'asksage', api_key: aiApiKeys.asksage, model:null, enabled:!!aiApiKeys.asksage })
+        ]);
+        alert('AI API Keys saved');
+      } catch(err) {
+        console.error('Failed to save AI API Keys', err);
+        alert('Failed to save AI API Keys');
+      }
     };
   }
 }

--- a/paoweb-supabase.js
+++ b/paoweb-supabase.js
@@ -290,6 +290,17 @@ async function addTemplate(form){
   await sb.from("templates").insert({ unit_id: CURRENT.unit_id, template_kind, value });
 }
 
+// ---------- AI Keys ----------
+async function saveAiKey({ unit_id, provider, api_key, model, enabled }) {
+  const token = (await sb.auth.getSession()).data.session?.access_token;
+  const res = await fetch(`${SUPABASE_URL}/functions/v1/set-ai-key`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ unit_id, provider, api_key, model, enabled })
+  });
+  if (!res.ok) throw new Error(await res.text());
+}
+
 // ---------- Bind UI ----------
 function bindUI(){
   // Populate unit selectors from Supabase when the page loads
@@ -321,5 +332,5 @@ function bindUI(){
   $("#form-template")?.addEventListener("submit", async e=>{ e.preventDefault(); await addTemplate(e.currentTarget); e.currentTarget.reset(); });
 }
 
-window.PAOWeb = { adminSignIn, startSignIn, loadUnitData, addOutput, addOuttake, addOutcome, setGoal, addTemplate, reloadUnits };
+window.PAOWeb = { adminSignIn, startSignIn, loadUnitData, addOutput, addOuttake, addOutcome, setGoal, addTemplate, reloadUnits, saveAiKey };
 document.addEventListener("DOMContentLoaded", bindUI);


### PR DESCRIPTION
## Summary
- add `saveAiKey` helper to call Supabase edge function for storing AI provider credentials
- wire admin UI to persist AI keys to Supabase for each provider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a608e073f8832893a3402898406d62