### PR TITLE
Add role selection to registration

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,13 @@
         <h3>Sign up</h3>
         <input id="su-email" type="email" placeholder="Email" required />
         <select id="unitSelectRegister" class="input"></select>
+        <label for="su-role">Role</label>
+        <select id="su-role" class="input" required>
+          <option value="">Select role…</option>
+          <option value="staff">Staff</option>
+          <option value="chief">PAO Chief</option>
+          <option value="admin">Admin</option>
+        </select>
         <input id="su-new-unit" type="text" class="input" placeholder="New unit name (optional)" data-new-unit-fields style="display:none" />
         <input id="su-new-code" type="text" class="input" placeholder="Unit code (optional)" data-new-unit-fields style="display:none" />
         <input id="su-pass" type="password" placeholder="Password" required />
@@ -892,6 +899,7 @@ function show(which, isBack=false){
     $('#chiefAuth').classList.add('hide');
     if (typeof reloadUnits === 'function') reloadUnits();
     else populateUnitSelect('#unitSelectRegister');
+    $('#su-role').value = '';
     return;
   }
   if(which==='adminReset'){
@@ -1830,6 +1838,7 @@ async function callAI(){
     const unit = $("unitSelectRegister").value;
     const newUnitName = $("su-new-unit").value.trim();
     const newUnitCode = $("su-new-code").value.trim();
+    const roleSel = $("su-role").value;
     const password = $("su-pass").value;
     const confirm = $("su-confirm").value;
     if (password !== confirm) {
@@ -1854,11 +1863,15 @@ async function callAI(){
       $("status").textContent = "Select a unit or enter a new unit name";
       return;
     }
+    if (!roleSel) {
+      $("status").textContent = "Select a role";
+      return;
+    }
     const displayName = email.split('@')[0];
     const { error } = await supabase.auth.signUp({
       email,
       password,
-      options: { data: { display_name: displayName, full_name: displayName, unit_id: unitId } }
+      options: { data: { display_name: displayName, full_name: displayName, unit_id: unitId, role: roleSel } }
     });
     $("status").textContent = error ? `Signup error: ${error.message}` : "Check email for confirmation.";
     if (!error) { await refreshAuthUI(); }


### PR DESCRIPTION
## Summary
- include labeled role dropdown with Staff, PAO Chief, and Admin options on sign up
- reset role selection when reopening registration screen and require a role before submitting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a60bff9fd083289a441880ea9621f4