### PR TITLE
Prompt user to choose role after unit selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -905,10 +905,7 @@ $('#btnUnitGo').addEventListener('click', ()=>{
   const unit=$('#unitSelectHome').value;
   if(!unit) return alert('Select a unit');
   db=load(unit);
-  role='viewer';
-  whoPill.textContent='Viewer';
-  buildViewer();
-  show('viewer');
+  show('role');
 });
 $('#screenRole').addEventListener('click', e=>{
   const card=e.target.closest('[data-role]'); if(!card) return;


### PR DESCRIPTION
## Summary
- After selecting a unit, display role-selection screen instead of defaulting to viewer role

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a648322ed88328bf034cbd1ae090a1