### PR TITLE
Fix Supabase sync to include unit id

### DIFF
--- a/index.html
+++ b/index.html
@@ -680,8 +680,11 @@ function save(){ localStorage.setItem(STORAGE_KEY, JSON.stringify(db)); ensureUn
 async function saveEntryToSupabase(entry){
   try{
     if(!window.supabase) return;
+    const unit_id = window.CURRENT?.unit_id;
+    if(!unit_id) return; // cannot save without a selected unit
     if(entry.type==='output'){
       await supabase.from('outputs').insert({
+        unit_id,
         user_id: entry.userId,
         timeframe: entry.tf,
         tf_key: entry.tfKey,
@@ -692,6 +695,7 @@ async function saveEntryToSupabase(entry){
       });
     }else if(entry.type==='outtake'){
       await supabase.from('outtakes').insert({
+        unit_id,
         user_id: entry.userId,
         timeframe: entry.tf,
         tf_key: entry.tfKey,
@@ -702,6 +706,7 @@ async function saveEntryToSupabase(entry){
       });
     }else if(entry.type==='outcome'){
       await supabase.from('outcomes').insert({
+        unit_id,
         user_id: entry.userId,
         timeframe: entry.tf,
         tf_key: entry.tfKey,
@@ -763,12 +768,13 @@ async function refreshCampaignProgress(){
 async function loadEntriesFromSupabase(){
   try{
     if(!window.supabase) return;
+    const unit_id = window.CURRENT?.unit_id;
     const { data: { user: u } } = await supabase.auth.getUser();
-    if(!u) return;
+    if(!u || !unit_id) return;
     const [outs, otks, ocms] = await Promise.all([
-      supabase.from('outputs').select('*').eq('user_id', u.id),
-      supabase.from('outtakes').select('*').eq('user_id', u.id),
-      supabase.from('outcomes').select('*').eq('user_id', u.id)
+      supabase.from('outputs').select('*').eq('user_id', u.id).eq('unit_id', unit_id),
+      supabase.from('outtakes').select('*').eq('user_id', u.id).eq('unit_id', unit_id),
+      supabase.from('outcomes').select('*').eq('user_id', u.id).eq('unit_id', unit_id)
     ]);
     const mapOuts = (outs.data||[]).map(o=>({id:o.id, userId:o.user_id, type:'output', tf:o.timeframe, tfKey:o.tf_key, ts:Date.parse(o.created_at), data:{product:o.product_type, qty:o.quantity, links:o.links||[], campaign:o.campaign_id||null}}));
     const mapOtks = (otks.data||[]).map(o=>({id:o.id, userId:o.user_id, type:'outtake', tf:o.timeframe, tfKey:o.tf_key, ts:Date.parse(o.created_at), data:{kind:o.outtake_type, qty:o.quantity, notes:o.notes||'', campaign:o.campaign_id||null}}));

--- a/paoweb-supabase.js
+++ b/paoweb-supabase.js
@@ -8,14 +8,24 @@
 const SUPABASE_URL = "https://ecgqsiysdteeagvacjna.supabase.co";
 const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVjZ3FzaXlzZHRlZWFndmFjam5hIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTU2OTUxMjcsImV4cCI6MjA3MTI3MTEyN30.IWgigXdAKcYlo_vrJpWljMXL3I0ySUmZo92smDEW2gs";
 
-const sb = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-  auth: {
-    storage: window.sessionStorage,
-    persistSession: true,
-    autoRefreshToken: true,
-    detectSessionInUrl: true
-  }
-});
+// Reuse an existing Supabase client if one was already created elsewhere on the
+// page.  The index.html file bootstraps a client for legacy flows, so this file
+// should gracefully adopt that instance instead of trying to create a new one.
+// If no client exists yet, fall back to creating our own.
+const sb = window.supabase?.from
+  ? window.supabase
+  : supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: {
+        storage: window.sessionStorage,
+        persistSession: true,
+        autoRefreshToken: true,
+        detectSessionInUrl: true
+      }
+    });
+
+// Expose the client globally so other scripts (like index.html) can use it and
+// so they don't attempt to spin up duplicate clients.
+window.supabase = sb;
 
 let CURRENT = {
   session: null,


### PR DESCRIPTION
## Summary
- adopt existing Supabase client instead of creating duplicates
- attach selected unit id when saving and loading entries so records sync to Supabase tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7c24b48608328b6e99f24c4ef8177