### PR TITLE
Ensure campaign updates propagate across unit

### DIFF
--- a/index.html
+++ b/index.html
@@ -1016,6 +1016,7 @@ function buildTfPicker(spanEl, tf, onChange){
   if(tf==='Y'){ const y=document.createElement('input'); y.type='number'; y.className='input'; y.style.width='100px'; y.value=year(today); y.addEventListener('input', ()=>onChange(String(y.value))); spanEl.appendChild(y); onChange(String(y.value)); }
 }
 function buildViewer(){
+  loadCampaigns();
   buildTfPicker(tfViewerPick, tfViewerSel.value, key=>{cur.key=key; refreshViewer();});
 }
 function refreshViewer(){

--- a/paoweb-supabase.js
+++ b/paoweb-supabase.js
@@ -85,6 +85,8 @@ async function switchUnit(unitId) {
     tearDownRealtime?.();
     await refreshRoleForUnit(unitId);
     await loadUnitData();
+    if (typeof loadCampaigns === 'function') await loadCampaigns();
+    if (typeof refreshCampaignProgress === 'function') await refreshCampaignProgress();
     subscribeRealtime?.();
   } catch (e) {
     console.error("switchUnit failed", e);


### PR DESCRIPTION
## Summary
- Refresh campaign list and progress when switching units
- Load campaigns when building the viewer dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7c607a0e8832898f1fc02373b661a