### PR TITLE
Fix admin sign-in navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1878,7 +1878,7 @@ async function callAI(){
     const uid = session.user.id;
     const { data: prof } = await supabase.from("profiles")
       .select("role, full_name, email")
-      .eq("id", uid)
+      .eq("user_id", uid)
       .single();
 
     role = prof?.role || role;


### PR DESCRIPTION
## Summary
- ensure admin sign-in loads profile using `user_id`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7c84dc85883288c9fe0ead8d775b9