### PR TITLE
feat: add role selection to staff sign up

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,8 @@
         <input id="su-email" type="email" placeholder="Email" required />
         <input id="su-pass" type="password" placeholder="Password" required />
         <input id="su-confirm" type="password" placeholder="Confirm password" required />
-        <select id="su-role">
+        <label for="su-role">Role</label>
+        <select id="su-role" class="input">
           <option value="staff">Staff</option>
           <option value="chief">PAO Chief</option>
         </select>
@@ -1821,7 +1822,8 @@ async function callAI(){
     const email = $("su-email").value.trim().toLowerCase();
     const password = $("su-pass").value;
     const confirm = $("su-confirm").value;
-    const role = $("su-role").value || 'staff';
+    let role = $("su-role").value || 'staff';
+    if (!['staff', 'chief'].includes(role)) role = 'staff';
     if (password !== confirm) {
       $("status").textContent = "Passwords do not match";
       return;

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "This is a self-contained web application that:",
   "main": "index.js",
   "scripts": {
-    "test": "npm run test:tooltip && npm run test:drawer",
+    "test": "npm run test:tooltip && npm run test:drawer && npm run test:role",
     "test:tooltip": "node tests/tooltip.test.js",
-    "test:drawer": "node tests/drawer-close.test.js"
+    "test:drawer": "node tests/drawer-close.test.js",
+    "test:role": "node tests/role-dropdown.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/role-dropdown.test.js
+++ b/tests/role-dropdown.test.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+const dom = new JSDOM(html);
+const select = dom.window.document.getElementById('su-role');
+const options = Array.from(select.options).map(o => o.value);
+
+if (options.includes('admin')) {
+  throw new Error('Admin role should not be present in role dropdown');
+}
+if (options.length !== 2 || !options.includes('staff') || !options.includes('chief')) {
+  throw new Error('Role dropdown must contain only staff and chief');
+}
+
+console.log('Role dropdown contains only staff and chief options');


### PR DESCRIPTION
## Summary
- add role dropdown to registration form for selecting Staff or PAO Chief
- guard against disallowed role values during sign up
- add test ensuring admin role is not an option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7c8e617a0832885810eb16b01fa59