### PR TITLE
docs: add auth users metadata migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ You can host this as a static page:
 
 Enjoy!
 
+## 🔐 Supabase Auth Setup
+
+The app uses Supabase for authentication. To surface fields like a user's
+`display_name` and `role` stored in the `raw_user_meta_data` JSON column of
+`auth.users`, run the SQL in `supabase/extend_auth_users.sql` against your
+Supabase project. The migration adds generated columns so these values can be
+queried directly without JSON operators.
+
 ## 🧪 Testing
 
 ### Automated check

--- a/supabase/extend_auth_users.sql
+++ b/supabase/extend_auth_users.sql
@@ -1,0 +1,7 @@
+-- Extend auth.users with generated metadata columns
+-- This migration exposes `display_name` and `role` stored in `raw_user_meta_data`
+-- so they can be queried directly without JSON operators.
+
+alter table auth.users
+  add column display_name text generated always as (raw_user_meta_data->>'display_name') stored,
+  add column role text generated always as (raw_user_meta_data->>'role') stored;


### PR DESCRIPTION
## Summary
- document how to expose Supabase auth user metadata as regular columns
- add SQL migration creating generated `display_name` and `role` columns

## Testing
- `npm run test:tooltip`


------
https://chatgpt.com/codex/tasks/task_e_68ad8bc7569c832896900f38a231261f