### PR TITLE
feat: add admin role to signup

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,7 @@
         <input id="su-confirm" type="password" placeholder="Confirm password" required />
         <label for="su-role">Role</label>
         <select id="su-role" class="input">
+          <option value="admin">Admin</option>
           <option value="staff">Staff</option>
           <option value="chief">PAO Chief</option>
         </select>
@@ -1841,7 +1842,7 @@ async function callAI(){
     const prof = await refreshAuthUI();
     const r = prof?.role || role;
     if (prof?.email) {
-      const labelMap = { admin: 'Register', chief: 'PAO Chief', staff: 'Staff' };
+      const labelMap = { admin: 'Admin', chief: 'PAO Chief', staff: 'Staff' };
       const label = labelMap[r] || (r ? r.charAt(0).toUpperCase() + r.slice(1) : 'User');
       whoPill.textContent = `${label} — ${prof.email}`;
     }
@@ -1855,7 +1856,7 @@ async function callAI(){
     const password = $("su-pass").value;
     const confirm = $("su-confirm").value;
     let role = $("su-role").value || 'staff';
-    if (!['staff', 'chief'].includes(role)) role = 'staff';
+    if (!['staff', 'chief', 'admin'].includes(role)) role = 'staff';
     if (password !== confirm) {
       $("status").textContent = "Passwords do not match";
       return;

--- a/tests/role-dropdown.test.js
+++ b/tests/role-dropdown.test.js
@@ -7,11 +7,8 @@ const dom = new JSDOM(html);
 const select = dom.window.document.getElementById('su-role');
 const options = Array.from(select.options).map(o => o.value);
 
-if (options.includes('admin')) {
-  throw new Error('Admin role should not be present in role dropdown');
-}
-if (options.length !== 2 || !options.includes('staff') || !options.includes('chief')) {
-  throw new Error('Role dropdown must contain only staff and chief');
+if (options.length !== 3 || !options.includes('admin') || !options.includes('staff') || !options.includes('chief')) {
+  throw new Error('Role dropdown must contain admin, staff, and chief');
 }
 
-console.log('Role dropdown contains only staff and chief options');
+console.log('Role dropdown contains admin, staff, and chief options');


### PR DESCRIPTION
## Summary
- allow selecting Admin role during registration
- support Admin role in signup logic
- update role dropdown test for admin option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1cfd1fa68832894d72a7cccd8ddf9