### PR TITLE
feat: invoke supabase edge functions for AI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1775,29 +1775,15 @@ const aiOutputEl=document.getElementById('aiOutput');
 async function callAI(){
   const prompt=aiPromptEl.value.trim();
   const provider=aiProviderEl.value;
-  const providerNames={openai:'OpenAI',gemini:'Gemini',camogpt:'CamoGPT',asksage:'AskSage'};
-  const key=aiApiKeys?.[provider]?.trim();
-  if(!key) return alert(providerNames[provider]+" API key not set by Admin.");
   if(!prompt) return alert('Enter a prompt first.');
   try{
-    let res,data;
-    if(provider==='openai'){
-      res=await fetch('https://api.openai.com/v1/chat/completions',{method:'POST',headers:{'Authorization':`Bearer ${key}`,'Content-Type':'application/json'},body:JSON.stringify({model:'gpt-4',messages:[{role:'user',content:prompt}]})});
-      data=await res.json();
-      aiOutputEl.textContent=data.choices?.[0]?.message?.content||'No response';
-    }else if(provider==='gemini'){
-      res=await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${key}`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({contents:[{parts:[{text:prompt}]}]})});
-      data=await res.json();
-      aiOutputEl.textContent=data.candidates?.[0]?.content?.parts?.[0]?.text||'No response';
-    }else if(provider==='camogpt'){
-      res=await fetch('https://api.camogpt.com/v1/chat/completions',{method:'POST',headers:{'Authorization':`Bearer ${key}`,'Content-Type':'application/json'},body:JSON.stringify({model:'camo-gpt',messages:[{role:'user',content:prompt}]})});
-      data=await res.json();
-      aiOutputEl.textContent=data.choices?.[0]?.message?.content||'No response';
-    }else if(provider==='asksage'){
-      res=await fetch('https://api.asksage.ai/v1/chat/completions',{method:'POST',headers:{'Authorization':`Bearer ${key}`,'Content-Type':'application/json'},body:JSON.stringify({model:'sage',messages:[{role:'user',content:prompt}]})});
-      data=await res.json();
-      aiOutputEl.textContent=data.choices?.[0]?.message?.content||'No response';
-    }
+    const data = await PAOWeb.askAi({ provider, prompt });
+    aiOutputEl.textContent =
+      data.result ||
+      data.answer ||
+      data.output ||
+      data.choices?.[0]?.message?.content ||
+      'No response';
   }catch(err){
     aiOutputEl.textContent='Error: '+err.message;
   }

--- a/paoweb-supabase.js
+++ b/paoweb-supabase.js
@@ -294,6 +294,17 @@ async function saveAiKey({ unit_id, provider, api_key, model, enabled }) {
   if (!res.ok) throw new Error(await res.text());
 }
 
+async function askAi({ provider, prompt, model }) {
+  const token = (await sb.auth.getSession()).data.session?.access_token;
+  const res = await fetch(`${SUPABASE_URL}/functions/v1/ask-ai`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ unit_id: CURRENT.unit_id, provider, prompt, model })
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+
 // ---------- Admin: Manage User Roles ----------
 async function setUserRole(user_id, role) {
   const { error } = await sb.from('roles').upsert({ user_id, role }, { onConflict: 'user_id' });
@@ -360,5 +371,5 @@ function bindUI(){
   $("#form-template")?.addEventListener("submit", async e=>{ e.preventDefault(); await addTemplate(e.currentTarget); e.currentTarget.reset(); });
 }
 
-window.PAOWeb = { adminSignIn, loadUnitData, addOutput, addOuttake, addOutcome, setGoal, addTemplate, reloadUnits, saveAiKey, switchUnit, loadAllUsers, setUserRole };
+window.PAOWeb = { adminSignIn, loadUnitData, addOutput, addOuttake, addOutcome, setGoal, addTemplate, reloadUnits, saveAiKey, askAi, switchUnit, loadAllUsers, setUserRole };
 document.addEventListener("DOMContentLoaded", bindUI);


### PR DESCRIPTION
## Summary
- add `askAi` helper that invokes Supabase edge function `ask-ai`
- route the Ask AI UI through `askAi` instead of direct provider calls

## Testing
- `npm run test:tooltip`


------
https://chatgpt.com/codex/tasks/task_e_68b3bb9f54cc8328b6d9d3c00c36f312