### PR TITLE
feat: add supabase server client

### DIFF
--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -1,0 +1,17 @@
+import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+export function supabaseServer() {
+  const store = cookies();
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (n) => store.get(n)?.value,
+        set: (n, v, o) => store.set({ name: n, value: v, ...o }),
+        remove: (n, o) => store.set({ name: n, value: '', ...o }),
+      } as unknown as CookieOptions,
+    }
+  );
+}


### PR DESCRIPTION
## Summary
- add server-side Supabase client helper using `@supabase/ssr`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b63b9c3be083288f8432ceccf86eac