### PR TITLE
Add API route for claiming invites

### DIFF
--- a/app/api/invites/claim/route.ts
+++ b/app/api/invites/claim/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { supabaseServer } from '@/lib/supabaseServer';
+export const runtime = 'edge';
+
+export async function POST(req: Request) {
+  const supabase = supabaseServer();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { unitId, role, code } = await req.json();
+  const { error } = await supabase.rpc('claim_invite', { p_code: code, p_unit: unitId, p_role: role });
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
## Summary
- add edge runtime API route to claim invite codes via Supabase RPC

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b63e0e33b08328aeafc8c1a0d5812c