### PR TITLE
Fix login role handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -1882,7 +1882,9 @@ async function callAI(){
     if (!error) {
       const userId = data.user?.id;
       if (userId) {
-        const { error: profileError } = await supabase.from("profiles").upsert({ id: userId, role });
+        const { error: profileError } = await supabase
+          .from("profiles")
+          .upsert({ user_id: userId, role });
         if (profileError) console.warn("Profile role set failed:", profileError.message);
       }
       await refreshAuthUI();
@@ -1922,24 +1924,32 @@ async function callAI(){
     }
 
     const uid = session.user.id;
-    const { data: prof } = await supabase.from("profiles")
+    let { data: prof } = await supabase
+      .from("profiles")
       .select("role, full_name, email")
       .eq("user_id", uid)
       .single();
 
-    role = prof?.role || role;
+    if (!prof) {
+      const meta = session.user.user_metadata || {};
+      prof = {
+        role: meta.role || null,
+        full_name: meta.full_name || meta.display_name || null,
+        email: session.user.email
+      };
+    }
+
+    role = prof.role || role;
     document.body.classList.toggle("is-admin", role === "admin");
-    $("status").textContent = `Signed in as ${prof?.email || session.user.email}`;
+    $("status").textContent = `Signed in as ${prof.email || session.user.email}`;
     user = {
       id: uid,
-      email: prof?.email || session.user.email,
-      name: prof?.full_name || prof?.email || session.user.email
+      email: prof.email || session.user.email,
+      name: prof.full_name || prof.email || session.user.email
     };
-    if (prof?.email) {
-      const labelMap = { admin: 'Register', chief: 'PAO Chief', staff: 'Staff' };
-      const label = labelMap[role] || (role ? role.charAt(0).toUpperCase() + role.slice(1) : 'User');
-      whoPill.textContent = `${label} — ${prof.email}`;
-    }
+    const labelMap = { admin: 'Register', chief: 'PAO Chief', staff: 'Staff' };
+    const label = labelMap[role] || (role ? role.charAt(0).toUpperCase() + role.slice(1) : 'User');
+    whoPill.textContent = `${label} — ${prof.email || session.user.email}`;
     resetIdle();
     await loadEntriesFromSupabase();
     const authScreens = new Set(['staffAuth','chiefAuth','adminAuth','adminReset']);


### PR DESCRIPTION
## Summary
- Ensure sign-up stores profile role using `user_id`
- Fallback to auth metadata in `refreshAuthUI` so role is detected and navigation proceeds after sign-in

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b64c5d76bc832884d64d858e53f4e3