### PR TITLE
Save local state to Supabase

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,7 +681,13 @@ function load(unit){
     return structuredClone(def);
   }
 }
-function save(){ localStorage.setItem(STORAGE_KEY, JSON.stringify(db)); ensureUnitList(currentUnit); }
+function save(){
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(db));
+  ensureUnitList(currentUnit);
+  if(window.PAOWeb?.saveUnitData){
+    window.PAOWeb.saveUnitData(db).catch(err=>console.error('Supabase save failed', err));
+  }
+}
 
 async function saveEntryToSupabase(entry){
   try{

--- a/paoweb-supabase.js
+++ b/paoweb-supabase.js
@@ -327,6 +327,19 @@ async function askAi({ provider, prompt, model }) {
   return res.json();
 }
 
+// ---------- Unit Data ----------
+async function saveUnitData(data) {
+  const sb = await sbPromise;
+  try {
+    const unit_id = CURRENT.unit_id;
+    const user_id = CURRENT.profile?.user_id || CURRENT.session?.user?.id;
+    if (!unit_id) return;
+    await sb.from('unit_data').upsert({ unit_id, user_id, data }, { onConflict: 'unit_id' });
+  } catch (err) {
+    console.error('saveUnitData failed', err);
+  }
+}
+
 // ---------- Admin: Manage User Roles ----------
 async function setUserRole(user_id, role) {
   const sb = await sbPromise;
@@ -395,5 +408,5 @@ function bindUI(){
   $("#form-template")?.addEventListener("submit", async e=>{ e.preventDefault(); await addTemplate(e.currentTarget); e.currentTarget.reset(); });
 }
 
-window.PAOWeb = { adminSignIn, loadUnitData, addOutput, addOuttake, addOutcome, setGoal, addTemplate, reloadUnits, saveAiKey, askAi, switchUnit, loadAllUsers, setUserRole };
+window.PAOWeb = { adminSignIn, loadUnitData, addOutput, addOuttake, addOutcome, setGoal, addTemplate, reloadUnits, saveAiKey, askAi, saveUnitData, switchUnit, loadAllUsers, setUserRole };
 document.addEventListener("DOMContentLoaded", bindUI);


### PR DESCRIPTION
## Summary
- Sync current unit data to Supabase in new `saveUnitData` helper
- Call `saveUnitData` from `save()` so units, users, and AI keys persist remotely

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b78aeb0ab883289e75af969270b012