### PR TITLE
Normalize PAO role strings for proper login redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1833,6 +1833,15 @@ async function callAI(){
   const $ = (id) => document.getElementById(id);
   const whoPill = $("whoPill");
 
+  function normalizeRole(role){
+    if(!role) return null;
+    const r = role.toLowerCase().replace(/\s+/g,'');
+    if(r.includes('chief') || r === 'pao') return 'chief';
+    if(r.includes('admin')) return 'admin';
+    if(r.includes('staff')) return 'staff';
+    return r;
+  }
+
   const IDLE_LIMIT = 30 * 60 * 1000;
   let idleTimer;
   function resetIdle(){
@@ -1845,7 +1854,7 @@ async function callAI(){
   window.nwwSignIn = async (email, password) => {
     email = (email || $("si-email").value).trim().toLowerCase();
     password = password || $("si-pass").value;
-    const selectedRole = window.role;
+    const selectedRole = normalizeRole(window.role);
     $("status").textContent = "Signing you in, please wait";
     const { error } = await supabase.auth.signInWithPassword({
       email,
@@ -1858,7 +1867,7 @@ async function callAI(){
     }
     $("status").textContent = "Signed in.";
     const prof = await refreshAuthUI();
-    const r = prof?.role || selectedRole;
+    const r = normalizeRole(prof?.role) || selectedRole;
     window.role = r;
     if (prof?.email) {
       const labelMap = { admin: 'Admin', chief: 'PAO Chief', staff: 'Staff' };
@@ -1874,7 +1883,7 @@ async function callAI(){
     const email = $("su-email").value.trim().toLowerCase();
     const password = $("su-pass").value;
     const confirm = $("su-confirm").value;
-    let role = $("su-role").value || 'staff';
+    let role = normalizeRole($("su-role").value || 'staff');
     if (!['staff', 'chief', 'admin'].includes(role)) role = 'staff';
     if (password !== confirm) {
       $("status").textContent = "Passwords do not match";
@@ -1947,7 +1956,9 @@ async function callAI(){
       };
     }
 
-    window.role = prof.role || window.role;
+    const normalizedRole = normalizeRole(prof.role);
+    window.role = normalizedRole || window.role;
+    prof.role = normalizedRole;
     document.body.classList.toggle("is-admin", window.role === "admin");
     $("status").textContent = `Signed in as ${prof.email || session.user.email}`;
     window.user = {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "description": "This is a self-contained web application that:",
   "main": "index.js",
   "scripts": {
-    "test": "npm run test:tooltip && npm run test:drawer && npm run test:role",
+    "test": "npm run test:tooltip && npm run test:drawer && npm run test:role && npm run test:normalizeRole",
     "test:tooltip": "node tests/tooltip.test.js",
     "test:drawer": "node tests/drawer-close.test.js",
-    "test:role": "node tests/role-dropdown.test.js"
+    "test:role": "node tests/role-dropdown.test.js",
+    "test:normalizeRole": "node tests/normalize-role.test.js"
   },
   "keywords": [],
   "author": "",

--- a/tests/normalize-role.test.js
+++ b/tests/normalize-role.test.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+const match = html.match(/function normalizeRole\(role\)\{[\s\S]*?\n\s*\}/);
+if (!match) throw new Error('normalizeRole function not found');
+const normalizeRole = new Function(match[0] + '; return normalizeRole;')();
+
+if (normalizeRole('PAO Chief') !== 'chief' || normalizeRole('pao') !== 'chief') {
+  throw new Error('normalizeRole should map "PAO" variations to "chief"');
+}
+
+console.log('normalizeRole handles PAO role strings');


### PR DESCRIPTION
## Summary
- Map standalone `PAO` role value to canonical `chief`
- Include unit test ensuring `normalizeRole` recognizes `PAO` as `chief`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc95908f20832895b3c82903a3484b